### PR TITLE
Refacto Canvas

### DIFF
--- a/src/components/Canvas/CanvasElement.tsx
+++ b/src/components/Canvas/CanvasElement.tsx
@@ -3,40 +3,8 @@
 import { ReactFlowProvider } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { CanvasInstance } from './CanvasInstance';
-import { io } from 'socket.io-client';
-import { useEffect, useState } from 'react';
-
-let socket;
 
 export const CanvasElement = () => {
-  const [ isConnected, setIsConnected ] = useState(false);
-
-  useEffect(() => {
-    if (!isConnected) {
-      console.log('start connexion');
-      socket = io('http://localhost:8080/', {
-        path: "/sqlizer/",
-        transportOptions: {
-          polling: {
-            extraHeaders: {
-              BearerToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjA1ZTkzNGU3LTgyMjAtNDY1My1hZjViLWI2MDM0MTY2OTY4MiIsImlhdCI6MTY5NTY2NDA4OSwiZXhwIjoxNjk2MjY4ODg5fQ._nRo_qloXaj-j4YFzVzOByFK4tJUlFDrJiCi6uZ16pY"
-            }
-          }
-        }
-      });
-      console.log(socket);
-      setIsConnected(true);
-    }
-  }, [isConnected])
-
-  // socket.on('lorem', () => {
-  //   console.log('ipsum');
-  // })
-
-  // socket.on('error', data => {
-  //   console.log('error');
-  //   console.log(data);
-  // })
 
   return (
     <>

--- a/src/components/Canvas/CanvasInstance.tsx
+++ b/src/components/Canvas/CanvasInstance.tsx
@@ -42,8 +42,6 @@ export const CanvasInstance = () => {
     if (!isFetching) console.log(sqlData)
   }, [sqlData, isFetching]);
 
-  const panOnDrag = [1, 2];
-
   return (
     <div className={styles.pagesContainer}>
       
@@ -68,7 +66,7 @@ export const CanvasInstance = () => {
           panOnScroll
           zoomOnDoubleClick={false}
           selectionOnDrag
-          panOnDrag={panOnDrag}
+          panOnDrag={[1, 2]}
           selectionMode={SelectionMode.Partial}
           >
         <Background color="#ccc" variant={variant} />

--- a/src/components/Canvas/CanvasInstance.tsx
+++ b/src/components/Canvas/CanvasInstance.tsx
@@ -5,7 +5,6 @@ import ReactFlow, {
   Panel,
   Controls,
   Background,
-  Node,
   BackgroundVariant,
   NodeTypes,
   useReactFlow,
@@ -19,7 +18,6 @@ import { InfosTable } from '../InfosTable/InfosTable';
 import { useDataToJson } from '@/hooks/useDataToJson';
 import { useDownloadSql } from '@/hooks/useDownloadSql'
 import { ConvertedData } from '../../types/tables';
-import { InfosTableType } from '../../types/infosTable';
 import { useApi } from '@/hooks/useApi';
 import { useNodes } from '@/hooks/useNodes';
 import { useAddTableNode } from '@/hooks/useAddTableNode';
@@ -38,27 +36,11 @@ export const CanvasInstance = () => {
   const { getNodes } = useReactFlow();
   const convertedData: ConvertedData | null = useDataToJson({ nodes, edges });
   const { downloadSql } = useDownloadSql(convertedData);
-  const [ tableInfos, setTableInfos ] = useState<InfosTableType>();
   const { sqlData, isFetching, fetchSQL } = useApi();
 
   useEffect(() => {
     if (!isFetching) console.log(sqlData)
-  }, [sqlData, isFetching])
-
-  // Prepare the infos to show at the left of the screen --> Infos of the table
-  useEffect(() => {
-    const tableParent = nodes.find((node) => node.selected === true && node.type != "fieldNode");
-    let fieldsChildren: any = []
-    if (tableParent) {
-      fieldsChildren = getNodes().filter((node: Node) => node.parentNode === tableParent.id);
-
-      setTableInfos({ 
-        tableParent: { id: tableParent?.id, data: tableParent?.data }, 
-        fieldsChildren: fieldsChildren
-        });
-    }
-
-  }, [nodes, getNodes])
+  }, [sqlData, isFetching]);
 
   const panOnDrag = [1, 2];
 
@@ -67,7 +49,7 @@ export const CanvasInstance = () => {
       
       {/* TABLE INFOS ON CLICK */}
       <div className={styles.infosTableContainer}>
-        <InfosTable infos={tableInfos} />
+        <InfosTable currentNodes={nodes} />
       </div>
 
       {/* CANVAS */}

--- a/src/components/InfosTable/InfosTable.module.css
+++ b/src/components/InfosTable/InfosTable.module.css
@@ -8,7 +8,6 @@
 }
 
 .titleTable {
-  
   margin: 48px 10vw;
   width: 19vw;
   text-align: center;

--- a/src/components/InfosTable/InfosTable.tsx
+++ b/src/components/InfosTable/InfosTable.tsx
@@ -3,23 +3,39 @@ import { useEffect, useState } from 'react';
 import { InfosTableType } from '../../types/infosTable';
 import { InfosField } from '../InfoField/InfoField';
 import { FieldModal } from '../FieldModal/FieldModal';
-import { useReactFlow } from 'reactflow';
+import { useReactFlow, Node } from 'reactflow';
+import { useNodes } from '@/hooks/useNodes';
 
 type InfosTableProps = {
-  infos: InfosTableType | undefined;
+  currentNodes: Node<any>[];
 }
 
-export const InfosTable = ({ infos }: InfosTableProps) => {
+export const InfosTable = ({ currentNodes }: InfosTableProps) => {
+  const [ tableInfos, setTableInfos ] = useState<InfosTableType>();
+  const { setNodes } = useNodes();
   const [ displayModal, setDisplayModal ] = useState(false);
-  const { getNodes, setNodes, getEdges, deleteElements } = useReactFlow();
+  const { getNodes, getEdges, deleteElements } = useReactFlow();
   const [ fieldToDisplay, setFieldToDisplay ] = useState("");
-  const [ currentTableInfo, setCurrentTableInfo ] = useState<any>();
   const [ displayInfos, setDisplayInfos ] = useState(false);
 
+  // Prepare the infos to show at the left of the screen --> Infos of the table
   useEffect(() => {
-    setCurrentTableInfo(infos);
+    const tableParent = currentNodes.find((node: Node) => node.selected === true && node.type != "fieldNode");
+    if (tableParent) {
+      let fieldsChildren: any[] = [];
+      fieldsChildren = getNodes().filter((node: Node) => node.parentNode === tableParent.id);
+
+      setTableInfos({ 
+        tableParent: { id: tableParent?.id, data: tableParent?.data }, 
+        fieldsChildren: fieldsChildren
+        });
+    }
+
+  }, [currentNodes, getNodes]);
+
+  useEffect(() => {
     setDisplayInfos(true);
-  }, [infos])
+  }, [tableInfos]);
 
   const handleUpdateField = (idField: string) => {
     setDisplayModal(true);
@@ -28,10 +44,10 @@ export const InfosTable = ({ infos }: InfosTableProps) => {
 
   const handleDropTable = () => {
     // Remove the tableNode and the fieldNode related to the table
-    const nodesToDelete = getNodes().filter((node) => node.id === currentTableInfo?.tableParent.id || node.parentNode === currentTableInfo?.tableParent.id);
+    const nodesToDelete = getNodes().filter((node) => node.id === tableInfos?.tableParent.id || node.parentNode === tableInfos?.tableParent.id);
 
     // Remove the edges related
-    const allNodesRelatedToTable = getNodes().filter((node) => node.id === currentTableInfo?.tableParent.id || node.parentNode === currentTableInfo?.tableParent.id);
+    const allNodesRelatedToTable = getNodes().filter((node) => node.id === tableInfos?.tableParent.id || node.parentNode === tableInfos?.tableParent.id);
     const allIds = allNodesRelatedToTable.map((node) => node.id);
     const edgesToDelete = getEdges().filter((edge) => allIds.includes(edge.source) || allIds.includes(edge.target));
     
@@ -56,16 +72,16 @@ export const InfosTable = ({ infos }: InfosTableProps) => {
 
   return (
     <>
-    { currentTableInfo?.tableParent?.data?.title && displayInfos ? (
+    { tableInfos?.tableParent?.data?.title && displayInfos ? (
       <div className={styleTableInfos.infosContainer}>
-        <h2 className={styleTableInfos.titleTable}>{currentTableInfo?.tableParent?.data?.title}</h2>
+        <h2 className={styleTableInfos.titleTable}>{tableInfos?.tableParent?.data?.title}</h2>
         <div className={styleTableInfos.infosFields}>
-          { currentTableInfo.fieldsChildren.map((node: any) => {
+          { tableInfos.fieldsChildren.map((node: any) => {
               return <InfosField key={node.id} idNode={node.id} data={node.data} updateField={() => handleUpdateField(node.id)} />
           }) }
         </div>
         <button className={styleTableInfos.dropTable} onClick={handleDropTable}>DROP TABLE</button>
-        {displayModal ? <FieldModal idTable={currentTableInfo?.tableParent.id} closeModal={closeModal} idField={fieldToDisplay} /> : ''}
+        {displayModal ? <FieldModal idTable={tableInfos?.tableParent.id} closeModal={closeModal} idField={fieldToDisplay} /> : ''}
       </div>
     ) : ('')}
     </>

--- a/src/hooks/useAddTableNode.ts
+++ b/src/hooks/useAddTableNode.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { useReactFlow, Node } from 'reactflow';
+import { useNodes } from '@/hooks/useNodes';
+
+const basicStyleTableNode: {} = {
+  width: "var(--baseWidthTableNode)",
+  minHeight: "var(--baseHeightTableNode)",
+  backgroundColor: "#fff",
+  border: "1.5px solid var(--borderColorTableNode)",
+  borderRadius: "2px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "top",
+  justifyContent: "flex-start",
+  color: "#000",
+}
+
+export const useAddTableNode = () => {
+  const { getNodes } = useReactFlow();
+  // const { nodes, setNodes } = useNodes();
+
+  // Add Table
+  const addTable = useCallback(() => {
+    const numberOfNodes = getNodes().length + 1;
+    const newTableNode: Node<any> = {id: numberOfNodes.toString(), type: 'tableNode', position: { x: -50, y: 0 }, data: { title: `NewTable${numberOfNodes}` }, style: basicStyleTableNode, expandParent: true};
+    // const newNodes = [...getNodes(), newTableNode];
+    // setNodes(newNodes);
+
+    // const tableSocket = { name: newTableNode.data.title, posX: newTableNode.position.x, posY: newTableNode.position.y, fields: [] }
+
+    // Returning the table, later will emit a socket
+    return newTableNode
+  }, [getNodes])
+
+  return { addTable }
+};

--- a/src/hooks/useDownloadSql.ts
+++ b/src/hooks/useDownloadSql.ts
@@ -7,11 +7,6 @@ export const useDownloadSql = (convertedData: ConvertedData | null) => {
   const [ apiSql, setApiSql ] = useState('');
   const { sqlData, isFetching, fetchSQL } = useApi();
 
-  // Api Call
-  // useEffect(() => {
-  //   fetchSQL(convertedData);
-  // }, [fetchSQL, convertedData])
-
   // Attribute the value when the call is finished
   useEffect(() => {
     if (!isFetching) setApiSql(sqlData)

--- a/src/hooks/useEdges.ts
+++ b/src/hooks/useEdges.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback, useRef } from 'react';
+import { Edge, OnEdgesChange, applyEdgeChanges, Connection, OnConnect, updateEdge, addEdge} from 'reactflow';
+
+const initialEdges = [{ id: 'Users.2-UsersGroup.3', source: '2', target: '4', animated: true }];
+
+export const useEdges = () => {
+  const [ edges, setEdges ] = useState<Edge[]>(initialEdges);
+  const edgeUpdateSuccessful = useRef(true);
+
+  const onEdgeUpdateStart = useCallback(() => {
+    edgeUpdateSuccessful.current = false;
+  }, []);
+
+  const onEdgesChange: OnEdgesChange = useCallback(
+    (changes) => setEdges((eds) => applyEdgeChanges(changes, eds)),
+    [setEdges]
+  );
+
+  const onEdgeUpdate = useCallback((oldEdge: Edge, newConnection: Connection) => {
+    edgeUpdateSuccessful.current = true;
+    setEdges((els) => updateEdge(oldEdge, newConnection, els));
+  }, []);
+
+  const onEdgeUpdateEnd = useCallback((_: any, edge: Edge) => {
+    if (!edgeUpdateSuccessful.current) {
+      setEdges((eds) => eds.filter((e) => e.id !== edge.id));
+    }
+
+    edgeUpdateSuccessful.current = true;
+  }, []);
+
+  const onConnect: OnConnect = useCallback(
+    (connection) => setEdges((eds) => addEdge(connection, eds)),
+    [setEdges]
+  );
+
+  return { edges, setEdges, onEdgeUpdateStart, onEdgesChange, onEdgeUpdate, onEdgeUpdateEnd, onConnect }
+}

--- a/src/hooks/useNodes.ts
+++ b/src/hooks/useNodes.ts
@@ -29,6 +29,6 @@ export const useNodes = () => {
     (changes) => setNodes((nds) => applyNodeChanges(changes, nds)),
     [setNodes]
   );
-
+  
   return { nodes, setNodes, onNodesChange }
 }

--- a/src/hooks/useNodes.ts
+++ b/src/hooks/useNodes.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+import { Node, OnNodesChange, applyNodeChanges,  } from 'reactflow';
+
+// initial Nodes and Style are temporary
+const basicStyleTableNode: {} = {
+  width: "var(--baseWidthTableNode)",
+  minHeight: "var(--baseHeightTableNode)",
+  backgroundColor: "#fff",
+  border: "1.5px solid var(--borderColorTableNode)",
+  borderRadius: "2px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "top",
+  justifyContent: "flex-start",
+  color: "#000",
+}
+
+const initialNodes = [
+  { id: '1', type: 'tableNode', position: { x: 0, y: 0 }, positionAbsolute: { x: 0, y: 0 }, data: { title: "Users" }, style: basicStyleTableNode, expandParent: true, selected: false, draggable: true },
+  { id: '2', type: 'fieldNode', position: { x: 0, y: 50 }, positionAbsolute: { x: 0, y: 50 }, data: { title: "Users.name", name: 'name', type: 'varchar(20)' }, parentNode: '1', draggable: false, selected: false },
+  { id: '3', type: 'tableNode', position: { x: -400, y: 50 }, positionAbsolute: { x: 0, y: 0 }, data: { title: "UsersGroup" }, style: basicStyleTableNode, expandParent: true, selected: false, draggable: true },
+  { id: '4', type: 'fieldNode', position: { x: 0, y: 50 }, positionAbsolute: { x: 0, y: 50 }, data: { title: "UsersGroup.name", name: 'name', type: 'varchar(20)' }, parentNode: '3', draggable: false, selected: false },
+];
+
+export const useNodes = () => {
+  const [ nodes, setNodes ] = useState<Node<any>[]>(initialNodes);
+
+  const onNodesChange: OnNodesChange = useCallback(
+    (changes) => setNodes((nds) => applyNodeChanges(changes, nds)),
+    [setNodes]
+  );
+
+  return { nodes, setNodes, onNodesChange }
+}

--- a/src/hooks/useSocketsManager.ts
+++ b/src/hooks/useSocketsManager.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { io, Socket } from "socket.io-client";
+import { getToken } from '@/utils/auth.utils';
+
+let socket: Socket;
+
+export const useSocketManager = () => {
+  const url = process.env.API_URL
+  if (!url) throw new Error("url is not defined");
+
+  useEffect(() => {
+    console.log('Start connexion');
+
+    const roomId = "fa1a2ace-f8da-4eb4-b123-2a816252d3aa";
+
+    socket = io(url, {
+      path: "/sqlizer/",
+      query: {
+        room: roomId,
+      },
+      transportOptions: {
+        polling: {
+          extraHeaders: {
+            BearerToken: getToken()
+          }
+        }
+      }
+    });
+
+    console.log(socket);
+    socket.on("socketError", (data) => console.log(data));
+    socket.on("responseCreateTable", (data) => console.log(data));
+  }, [url])
+}

--- a/src/styles/auth.css
+++ b/src/styles/auth.css
@@ -1,4 +1,4 @@
-*, *::before, *::after {
+/* *, *::before, *::after {
   box-sizing: border-box;
 }
 
@@ -91,4 +91,4 @@ input[type="button"]:hover {
 input[type="button"],
 input[type="submit"] {
   appearance: none;
-}
+} */

--- a/src/styles/page.module.css
+++ b/src/styles/page.module.css
@@ -11,7 +11,8 @@
   width: 20%;
   height: 100%;
   background: #fff;
-  border-right: 2px solid #000
+  border-right: 2px solid #000;
+  z-index: 15;
 }
 
 .canvasContainer {

--- a/src/utils/auth.utils.ts
+++ b/src/utils/auth.utils.ts
@@ -1,6 +1,7 @@
 import { getAxiosInstance } from "@/api/axios";
 
 export const setToken = (token: string) => {
+    localStorage.removeItem('token')
     localStorage.setItem('token', token)
 }
 


### PR DESCRIPTION
# Main changes
- Nodes & Edges are managed in a separated hook
- Creating a table is also managed in a seperated hook
- Logic of Infos table is more centralized in its own component

## Others
- Clean PanOnDrag to leave space
- auth.css in commentaries because of selectors
- z-index added in style for the infosTableContainer
- Init socketManager that would be used in the next PR